### PR TITLE
Fix error reporting in verbose mode

### DIFF
--- a/integration/queue_worker_test.go
+++ b/integration/queue_worker_test.go
@@ -50,6 +50,8 @@ func TestQueueWorker(t *testing.T) {
 		}
 	}
 
+	logger := io.Discard
+
 	t.Run("It consumes all messages from the queue and exits", func(t *testing.T) {
 		for i := 0; i < 1000; i++ {
 			rmq.Publish([]byte(fmt.Sprintf("product-%d", i)), "test.product")
@@ -57,7 +59,7 @@ func TestQueueWorker(t *testing.T) {
 			rmq.Publish([]byte(fmt.Sprintf("user-%d", i)), "test.user")
 		}
 
-		worker := queue.NewWorker(rmq.Connection(), queues, false, []string{}, "rabbitmq/consumer", []string{"./consumer", hostPort, queueChunkSize})
+		worker := queue.NewWorker(rmq.Connection(), queues, false, []string{}, "rabbitmq/consumer", []string{"./consumer", hostPort, queueChunkSize}, logger)
 		worker.Execute(ctx)
 
 		for _, queue := range queues {
@@ -79,7 +81,7 @@ func TestQueueWorker(t *testing.T) {
 			rmq.Publish([]byte(fmt.Sprintf("user-%d", i)), "test.user")
 		}
 
-		worker := queue.NewWorker(rmq.Connection(), queues, true, []string{}, "rabbitmq/consumer", []string{"./consumer", hostPort, queueChunkSize})
+		worker := queue.NewWorker(rmq.Connection(), queues, true, []string{}, "rabbitmq/consumer", []string{"./consumer", hostPort, queueChunkSize}, logger)
 		go worker.Execute(ctx)
 
 		time.Sleep(3 * time.Second)

--- a/queue/service.go
+++ b/queue/service.go
@@ -2,8 +2,8 @@ package queue
 
 import (
 	"context"
-	"os"
 
+	"github.com/Adaendra/uilive"
 	"github.com/hgajjar/toolbox/config"
 
 	amqp "github.com/rabbitmq/amqp091-go"
@@ -16,7 +16,11 @@ func StartWorker(ctx context.Context, rabbitmqConnString string, queues []string
 		zerolog.SetGlobalLevel(zerolog.DebugLevel)
 	}
 
-	logger := zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr}).With().Timestamp().Logger()
+	writer := uilive.New()
+	writer.Start()
+	defer writer.Stop()
+
+	logger := zerolog.New(zerolog.ConsoleWriter{Out: writer.Bypass()}).With().Timestamp().Logger()
 
 	// Attach the Logger to the context.Context
 	ctx = logger.WithContext(ctx)
@@ -27,6 +31,6 @@ func StartWorker(ctx context.Context, rabbitmqConnString string, queues []string
 	}
 	defer conn.Close()
 
-	worker := NewWorker(conn, queues, daemonMode, cmdPrefix, cmdDir, cmd)
+	worker := NewWorker(conn, queues, daemonMode, cmdPrefix, cmdDir, cmd, writer)
 	worker.Execute(ctx)
 }

--- a/sync/exporter.go
+++ b/sync/exporter.go
@@ -86,10 +86,10 @@ func (e *Exporter) listenRabbitMqNotifications(ctx context.Context) {
 		for b := range blockings {
 			if b.Active {
 				e.connIsBlocked = true
-				logger.Debug().Msgf("RabbitMQ connection blocked: %q", b.Reason)
+				logger.Warn().Msgf("RabbitMQ connection blocked: %q", b.Reason)
 			} else {
 				e.connIsBlocked = false
-				logger.Debug().Msgf("RabbitMQ connection unblocked")
+				logger.Info().Msgf("RabbitMQ connection unblocked")
 			}
 		}
 	}(ctx, e)


### PR DESCRIPTION
### Issue:
When you run the `sync:data` command with `--run-queue-worker` flag in verbose mode, it starts both data sync and queue worker processes in parallel. Since the verbose mode is ON, queue worker would print the live output of pending message count for all queues. In this case, if sync data process also prints some log output (warning/info messages), these messages gets overwritten by queue worker's live output.

### Changes:
Keep the "static" messages while printing live output.

### Screen recording:
Before: 
[before.webm](https://github.com/user-attachments/assets/d679b573-e14e-4999-b8f2-3ae1ade49a12)

After:
[after.webm](https://github.com/user-attachments/assets/1ae11203-8fef-4763-890c-72773dfb7349)