### PR TITLE
Add wait loop for queue worker while in daemon mode

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/spf13/viper"
 )
@@ -30,6 +31,8 @@ const (
 	postgresUserKey             = "postgres.user"
 	postgresPasswordKey         = "postgres.password"
 	postgresDatabaseKey         = "postgres.database"
+
+	QueueDeclareRetryWait = time.Second * 30
 )
 
 func init() {

--- a/integration/queue_worker_test.go
+++ b/integration/queue_worker_test.go
@@ -59,7 +59,7 @@ func TestQueueWorker(t *testing.T) {
 			rmq.Publish([]byte(fmt.Sprintf("user-%d", i)), "test.user")
 		}
 
-		worker := queue.NewWorker(rmq.Connection(), queues, false, []string{}, "rabbitmq/consumer", []string{"./consumer", hostPort, queueChunkSize}, logger)
+		worker := queue.NewWorker(rmq.Connection(), queues, false, []string{}, "rabbitmq/consumer", []string{"./consumer", hostPort, queueChunkSize}, logger, config.QueueDeclareRetryWait)
 		worker.Execute(ctx)
 
 		for _, queue := range queues {
@@ -74,6 +74,45 @@ func TestQueueWorker(t *testing.T) {
 		}
 	})
 
+	t.Run("It waits for queues to be available and can process messages that came later in daemon mode", func(t *testing.T) {
+		newQueues := []string{"test.product.new", "test.category.new", "test.user.new"}
+		worker := queue.NewWorker(rmq.Connection(), newQueues, true, []string{}, "rabbitmq/consumer", []string{"./consumer", hostPort, queueChunkSize}, logger, 2*time.Second)
+		go worker.Execute(ctx)
+
+		time.Sleep(3 * time.Second)
+
+		for _, queue := range newQueues {
+			if err := rmq.Queue(queue); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		for i := 0; i < 10; i++ {
+			rmq.Publish([]byte(fmt.Sprintf("product-%d", i)), "test.product.new")
+			rmq.Publish([]byte(fmt.Sprintf("category-%d", i)), "test.category.new")
+			rmq.Publish([]byte(fmt.Sprintf("user-%d", i)), "test.user.new")
+		}
+
+		for _, queue := range newQueues {
+		loop:
+			for {
+				select {
+				case <-time.After(5 * time.Second):
+					t.Fatalf("timed-out while waiting for queue %s to get empty", queue)
+				default:
+					count, err := rmq.GetMessageCount(queue)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if count == 0 {
+						break loop
+					}
+					time.Sleep(500 * time.Millisecond)
+				}
+			}
+		}
+	})
+
 	t.Run("It consumes all existing and new messages from the queue and keeps running in daemon mode", func(t *testing.T) {
 		for i := 0; i < 1000; i++ {
 			rmq.Publish([]byte(fmt.Sprintf("product-%d", i)), "test.product")
@@ -81,7 +120,7 @@ func TestQueueWorker(t *testing.T) {
 			rmq.Publish([]byte(fmt.Sprintf("user-%d", i)), "test.user")
 		}
 
-		worker := queue.NewWorker(rmq.Connection(), queues, true, []string{}, "rabbitmq/consumer", []string{"./consumer", hostPort, queueChunkSize}, logger)
+		worker := queue.NewWorker(rmq.Connection(), queues, true, []string{}, "rabbitmq/consumer", []string{"./consumer", hostPort, queueChunkSize}, logger, config.QueueDeclareRetryWait)
 		go worker.Execute(ctx)
 
 		time.Sleep(3 * time.Second)

--- a/queue/connection.go
+++ b/queue/connection.go
@@ -1,0 +1,63 @@
+package queue
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+	"github.com/rs/zerolog"
+)
+
+type connection struct {
+	args WorkerArgs
+}
+
+func NewConnection(args WorkerArgs) *connection {
+	return &connection{args: args}
+}
+
+func (c *connection) Setup(ctx context.Context, args WorkerArgs) (*amqp.Connection, error) {
+	logger := zerolog.Ctx(ctx)
+	conn, err := amqp.Dial(args.RabbitmqConnString)
+	if err != nil {
+		if !args.DaemonMode {
+			return nil, errors.New("failed to connect to RabbitMQ")
+		}
+
+		// In daemon mode, we wait and retry connection with exponential backoff
+		logger.Error().Err(err).Msg("failed to connect to RabbitMQ, retrying...")
+		conn, err = c.waitAndRetry(ctx, args.RabbitmqConnString, logger)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return conn, nil
+}
+
+func (c *connection) waitAndRetry(ctx context.Context, connString string, logger *zerolog.Logger) (*amqp.Connection, error) {
+	var conn *amqp.Connection
+	var err error
+
+	backoff := time.Second
+
+	for {
+		conn, err = amqp.Dial(connString)
+		if err == nil {
+			logger.Info().Msg("successfully connected to RabbitMQ")
+			return conn, nil
+		}
+
+		logger.Error().Err(err).Msgf("retrying connection in %v seconds...", backoff)
+
+		select {
+		case <-ctx.Done():
+			return nil, errors.New("context cancelled, stopping retry attempts")
+		case <-time.After(c.args.connectionTimeout):
+			return nil, errors.New("connection timeout reached, stopping retry attempts")
+		case <-time.After(backoff):
+			backoff *= 2
+		}
+	}
+}

--- a/queue/connection_test.go
+++ b/queue/connection_test.go
@@ -1,0 +1,63 @@
+package queue
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestConnection_New(t *testing.T) {
+	args := WorkerArgs{
+		RabbitmqConnString: "amqp://guest:guest@localhost:5672/",
+	}
+	conn := NewConnection(args)
+	if conn == nil {
+		t.Fatal("Expected NewConnection to return a non-nil connection")
+	}
+
+	if conn.args.RabbitmqConnString != args.RabbitmqConnString {
+		t.Fatalf("Expected RabbitmqConnString to be %s, got %s", args.RabbitmqConnString, conn.args.RabbitmqConnString)
+	}
+}
+
+func TestConnection_Setup(t *testing.T) {
+	t.Run("It should return an error when RabbitMQ is not running", func(t *testing.T) {
+		t.Parallel()
+
+		args := WorkerArgs{
+			RabbitmqConnString: "amqp://guest:guest@invalid-host:5672/",
+			DaemonMode:         false,
+		}
+		conn := NewConnection(args)
+		ctx := context.Background()
+
+		_, err := conn.Setup(ctx, args)
+		if err == nil {
+			t.Fatal("Expected Setup to return an error when RabbitMQ is not running")
+		}
+	})
+
+	t.Run("It should retry connection in DaemonMode", func(t *testing.T) {
+		t.Parallel()
+
+		args := WorkerArgs{
+			RabbitmqConnString: "amqp://guest:guest@invalid-host:5672/",
+			DaemonMode:         true,
+			connectionTimeout:  time.Second * 3,
+		}
+		conn := NewConnection(args)
+		ctx := context.Background()
+		start := time.Now()
+
+		_, err := conn.Setup(ctx, args)
+		if err == nil {
+			t.Fatal("Expected Setup to return an error after retrying in DaemonMode when RabbitMQ is not running")
+		}
+
+		// check if it waited at least the timeout duration
+		elapsed := time.Since(start)
+		if elapsed < args.connectionTimeout {
+			t.Fatalf("Expected Setup to wait at least %v, but it waited %v", args.connectionTimeout, elapsed)
+		}
+	})
+}

--- a/queue/service.go
+++ b/queue/service.go
@@ -2,10 +2,9 @@ package queue
 
 import (
 	"context"
+	"time"
 
 	"github.com/hgajjar/toolbox/container"
-
-	amqp "github.com/rabbitmq/amqp091-go"
 )
 
 type WorkerArgs struct {
@@ -15,6 +14,7 @@ type WorkerArgs struct {
 	CmdPrefix          []string
 	CmdDir             string
 	Cmd                []string
+	connectionTimeout  time.Duration
 }
 
 func StartWorker(ctx context.Context, dic *container.Container, args WorkerArgs) {
@@ -26,9 +26,10 @@ func StartWorker(ctx context.Context, dic *container.Container, args WorkerArgs)
 	// Attach the Logger to the context.Context
 	ctx = logger.WithContext(ctx)
 
-	conn, err := amqp.Dial(args.RabbitmqConnString)
+	args.connectionTimeout = time.Hour
+	conn, err := NewConnection(args).Setup(ctx, args)
 	if err != nil {
-		logger.Panic().Err(err).Msg("Failed to connect to RabbitMQ")
+		logger.Panic().Err(err).Msg("failed to establish RabbitMQ connection")
 	}
 	defer conn.Close()
 

--- a/queue/service.go
+++ b/queue/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/hgajjar/toolbox/config"
 	"github.com/hgajjar/toolbox/container"
 )
 
@@ -33,6 +34,6 @@ func StartWorker(ctx context.Context, dic *container.Container, args WorkerArgs)
 	}
 	defer conn.Close()
 
-	worker := NewWorker(conn, args.Queues, args.DaemonMode, args.CmdPrefix, args.CmdDir, args.Cmd, writer)
+	worker := NewWorker(conn, args.Queues, args.DaemonMode, args.CmdPrefix, args.CmdDir, args.Cmd, writer, config.QueueDeclareRetryWait)
 	worker.Execute(ctx)
 }

--- a/queue/worker.go
+++ b/queue/worker.go
@@ -18,26 +18,28 @@ import (
 )
 
 type Worker struct {
-	conn             *amqp.Connection
-	queues           []string
-	daemonMode       bool
-	consoleCmdPrefix []string
-	consoleCmdDir    string
-	consoleCmd       []string
-	logger           io.Writer
+	conn                  *amqp.Connection
+	queues                []string
+	daemonMode            bool
+	consoleCmdPrefix      []string
+	consoleCmdDir         string
+	consoleCmd            []string
+	logger                io.Writer
+	queueDeclareRetryWait time.Duration
 }
 
 type queueMessageMap map[string]int
 
-func NewWorker(conn *amqp.Connection, queues []string, daemonMode bool, cmdPrefix []string, cmdDir string, cmd []string, logger io.Writer) *Worker {
+func NewWorker(conn *amqp.Connection, queues []string, daemonMode bool, cmdPrefix []string, cmdDir string, cmd []string, logger io.Writer, queueDeclareRetryWait time.Duration) *Worker {
 	return &Worker{
-		conn:             conn,
-		queues:           queues,
-		daemonMode:       daemonMode,
-		consoleCmdPrefix: cmdPrefix,
-		consoleCmdDir:    cmdDir,
-		consoleCmd:       cmd,
-		logger:           logger,
+		conn:                  conn,
+		queues:                queues,
+		daemonMode:            daemonMode,
+		consoleCmdPrefix:      cmdPrefix,
+		consoleCmdDir:         cmdDir,
+		consoleCmd:            cmd,
+		logger:                logger,
+		queueDeclareRetryWait: queueDeclareRetryWait,
 	}
 }
 
@@ -61,7 +63,7 @@ func (w *Worker) Execute(ctx context.Context) {
 
 		go func(ctx context.Context, queue string) {
 			defer wg.Done()
-			err := w.startQueueProcess(ctx, queue, qMap, &queueMapLock)
+			err := w.startQueueProcessWithWaitLoop(ctx, queue, qMap, &queueMapLock)
 			if err != nil {
 				zerolog.Ctx(ctx).Error().Stack().Err(err).Msg(err.Error())
 			}
@@ -113,6 +115,16 @@ func (w *Worker) sortMapKeys(queues queueMessageMap) []string {
 	sort.Strings(keys)
 
 	return keys
+}
+
+func (w *Worker) startQueueProcessWithWaitLoop(ctx context.Context, queue string, qMap queueMessageMap, queueMapLock *sync.RWMutex) error {
+	err := w.startQueueProcess(ctx, queue, qMap, queueMapLock)
+	if err != nil && w.daemonMode {
+		time.Sleep(w.queueDeclareRetryWait)
+		return w.startQueueProcessWithWaitLoop(ctx, queue, qMap, queueMapLock)
+	}
+
+	return nil
 }
 
 func (w *Worker) startQueueProcess(ctx context.Context, queue string, queues queueMessageMap, queueMapLock *sync.RWMutex) error {

--- a/queue/worker.go
+++ b/queue/worker.go
@@ -124,7 +124,7 @@ func (w *Worker) startQueueProcessWithWaitLoop(ctx context.Context, queue string
 		return w.startQueueProcessWithWaitLoop(ctx, queue, qMap, queueMapLock)
 	}
 
-	return nil
+	return err
 }
 
 func (w *Worker) startQueueProcess(ctx context.Context, queue string, queues queueMessageMap, queueMapLock *sync.RWMutex) error {

--- a/sync/service.go
+++ b/sync/service.go
@@ -70,7 +70,7 @@ func RunSyncData(ctx context.Context, dic *container.Container, args SyncDataArg
 
 func startQueueWorker(ctx context.Context, queues []string, conn *amqp.Connection, daemonMode bool, cmdPrefix []string, cmdDir string, cmd []string, writer io.Writer) (<-chan any, *queue.Worker) {
 	done := make(chan any)
-	worker := queue.NewWorker(conn, queues, daemonMode, cmdPrefix, cmdDir, cmd, writer)
+	worker := queue.NewWorker(conn, queues, daemonMode, cmdPrefix, cmdDir, cmd, writer, config.QueueDeclareRetryWait)
 
 	go func(ctx context.Context, worker *queue.Worker) {
 		worker.Execute(ctx)


### PR DESCRIPTION
### Issue
When you start the queue worker, it tries to connect to RabbitMQ. If it can't, it fails immediately. This is okay for running the queue-worker as a one-off command.
However, when you run the queue worker in daemon mode, the connection to RabbitMQ might not be available yet. So, it fails and exits the process.
Another problem - if the RabbiMQ connection is working, but queues does not exist yet, it also fails and exits.

### Solution
In Daemon mode,
- Wait for RabbitMQ connection to be available. If it is not available, it waits with exponential backoff until a one hour timeout
- Wait for queues to be declared, and goes into loop with 30 sec internal to recheck