### PR TITLE
Fix search resource sync payload

### DIFF
--- a/application/cmd/queue_worker.go
+++ b/application/cmd/queue_worker.go
@@ -1,19 +1,14 @@
 package cmd
 
 import (
-	"strings"
-
 	"github.com/hgajjar/toolbox/config"
 	"github.com/hgajjar/toolbox/container"
 	"github.com/hgajjar/toolbox/queue"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 const (
-	queueNamesKey = "worker.queues"
-
 	argDaemonMode      = "daemon-mode"
 	argDaemonModeShort = "d"
 	argDaemonModeUsage = `Keep queue workers running in daemon mode.`
@@ -42,24 +37,15 @@ func NewQueueWorkerCmd() *QueueWorkerCmd {
 var queueWorkerCmd = &cobra.Command{
 	Use: "queue:worker",
 	Run: func(cmd *cobra.Command, args []string) {
-		queues := viper.GetStringSlice(queueNamesKey)
-
-		cmdPrefix := strings.Split(viper.GetString(config.ConsoleCmdPrefixKey), " ")
-		cmdDir := viper.GetString(config.ConsoleCmdDirKey)
-		consoleCmd := strings.Split(viper.GetString(config.ConsoleCmdKey), " ")
+		cfg := config.New()
 
 		workerArgs := queue.WorkerArgs{
-			RabbitmqConnString: config.GetRabbitMQConnectionString(),
-			Queues:             queues,
-			DaemonMode:         daemonModeOpt,
-			CmdPrefix:          cmdPrefix,
-			CmdDir:             cmdDir,
-			Cmd:                consoleCmd,
+			DaemonMode: daemonModeOpt,
 		}
 
 		dic := container.New()
 		defer dic.Close()
 
-		queue.StartWorker(cmd.Context(), dic, workerArgs)
+		queue.StartWorker(cmd.Context(), dic, cfg, workerArgs)
 	},
 }

--- a/application/cmd/queue_worker.go
+++ b/application/cmd/queue_worker.go
@@ -58,6 +58,7 @@ var queueWorkerCmd = &cobra.Command{
 		}
 
 		dic := container.New()
+		defer dic.Close()
 
 		queue.StartWorker(cmd.Context(), dic, workerArgs)
 	},

--- a/application/cmd/sync_data.go
+++ b/application/cmd/sync_data.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"log"
-	"strings"
-
 	"github.com/hgajjar/toolbox/config"
 	"github.com/hgajjar/toolbox/container"
 	"github.com/hgajjar/toolbox/sync"
@@ -27,8 +24,6 @@ If not, full export will be executed.`
 	argRunQueueWorker      = "run-queue-worker"
 	argRunQueueWorkerShort = "q"
 	argRunQueueWorkerUsage = `Run queue workers in the background.`
-
-	syncDataEntitiesKey = "sync-data.entities"
 )
 
 var (
@@ -59,28 +54,9 @@ func (s *SyncDataCmd) Cmd() *cobra.Command {
 var syncDataCmd = &cobra.Command{
 	Use: "sync:data",
 	Run: func(cmd *cobra.Command, args []string) {
-		queues := viper.GetStringSlice(queueNamesKey)
-
-		cmdPrefix := strings.Split(viper.GetString(config.ConsoleCmdPrefixKey), " ")
-		cmdDir := viper.GetString(config.ConsoleCmdDirKey)
-		consoleCmd := strings.Split(viper.GetString(config.ConsoleCmdKey), " ")
-
-		resourceFilter := viper.GetString(argResource)
-
-		var syncConfigEntities []config.SyncEntity
-
-		err := viper.UnmarshalKey(syncDataEntitiesKey, &syncConfigEntities)
-		if err != nil {
-			log.Panicf("Failed to parse sync-data.entities config: %s", err)
-		}
+		cfg := config.New()
 
 		syncDataArgs := sync.SyncDataArgs{
-			Queues:            queues,
-			CmdPrefix:         cmdPrefix,
-			CmdDir:            cmdDir,
-			Cmd:               consoleCmd,
-			SyncDataEntities:  syncConfigEntities,
-			ResourceFilter:    resourceFilter,
 			IDsOpt:            idsOpt,
 			RunQueueWorkerOpt: runQueueWorkerOpt,
 		}
@@ -91,6 +67,7 @@ var syncDataCmd = &cobra.Command{
 		sync.RunSyncData(
 			cmd.Context(),
 			dic,
+			cfg,
 			syncDataArgs,
 		)
 	},

--- a/application/cmd/sync_data.go
+++ b/application/cmd/sync_data.go
@@ -75,16 +75,14 @@ var syncDataCmd = &cobra.Command{
 		}
 
 		syncDataArgs := sync.SyncDataArgs{
-			Queues:             queues,
-			CmdPrefix:          cmdPrefix,
-			CmdDir:             cmdDir,
-			Cmd:                consoleCmd,
-			SyncDataEntities:   syncConfigEntities,
-			ResourceFilter:     resourceFilter,
-			IDsOpt:             idsOpt,
-			RunQueueWorkerOpt:  runQueueWorkerOpt,
-			RabbitmqConnString: config.GetRabbitMQConnectionString(),
-			PostgresConnString: config.GetPostgresConnectionString(),
+			Queues:            queues,
+			CmdPrefix:         cmdPrefix,
+			CmdDir:            cmdDir,
+			Cmd:               consoleCmd,
+			SyncDataEntities:  syncConfigEntities,
+			ResourceFilter:    resourceFilter,
+			IDsOpt:            idsOpt,
+			RunQueueWorkerOpt: runQueueWorkerOpt,
 		}
 
 		dic := container.New()

--- a/application/cmd/sync_data.go
+++ b/application/cmd/sync_data.go
@@ -88,6 +88,7 @@ var syncDataCmd = &cobra.Command{
 		}
 
 		dic := container.New()
+		defer dic.Close()
 
 		sync.RunSyncData(
 			cmd.Context(),

--- a/config/config.go
+++ b/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"strings"
 	"time"
@@ -18,6 +19,11 @@ const (
 	ConsoleCmdPrefixKey = "consoleCmdPrefix"
 	ConsoleCmdDirKey    = "consoleCmdDir"
 	ConsoleCmdKey       = "consoleCmd"
+
+	queueNamesKey       = "worker.queues"
+	syncDataEntitiesKey = "sync-data.entities"
+
+	resourceKey = "resource"
 
 	rabbitmqConnectionStringKey = "rabbitmq.connection-string"
 	rabbitmqServerKey           = "rabbitmq.server"
@@ -52,33 +58,84 @@ func init() {
 	Verbose = countVerbosityLevel(os.Args)
 }
 
-func GetRabbitMQConnectionString() string {
-	rabbitmqConnStr := viper.GetString(rabbitmqConnectionStringKey)
-	if rabbitmqConnStr != "" {
-		return rabbitmqConnStr
-	}
+type Config struct {
+	ConsoleCmdPrefix []string
+	ConsoleCmdDir    string
+	ConsoleCmd       []string
 
-	rabbitmqServer := viper.GetString(rabbitmqServerKey)
-	rabbitmqPort := viper.GetInt(rabbitmqPortKey)
-	rabbitmqUser := viper.GetString(rabbitmqUserKey)
-	rabbitmqPassword := viper.GetString(rabbitmqPasswordKey)
+	QueueNames       []string
+	SyncDataEntities []SyncEntity
 
-	return fmt.Sprintf("amqp://%s:%s@%s:%d/", rabbitmqUser, rabbitmqPassword, rabbitmqServer, rabbitmqPort)
+	ResourceFilter string
+
+	RabbitMq RabbitMQ
+	Postgres Postgres
 }
 
-func GetPostgresConnectionString() string {
-	postgresConnStr := viper.GetString(postgresConnectionStringKey)
-	if postgresConnStr != "" {
-		return postgresConnStr
+type RabbitMQ struct {
+	ConnectionString string
+	Server           string
+	Port             int
+	User             string
+	Password         string
+}
+
+type Postgres struct {
+	ConnectionString string
+	Server           string
+	Port             int
+	User             string
+	Password         string
+	Database         string
+}
+
+func New() *Config {
+	var syncConfigEntities []SyncEntity
+
+	err := viper.UnmarshalKey(syncDataEntitiesKey, &syncConfigEntities)
+	if err != nil {
+		log.Panicf("Failed to parse sync-data.entities config: %s", err)
 	}
 
-	postgresServer := viper.GetString(postgresServerKey)
-	postgresPort := viper.GetInt(postgresPortKey)
-	postgresUser := viper.GetString(postgresUserKey)
-	postgresPassword := viper.GetString(postgresPasswordKey)
-	postgresDatabase := viper.GetString(postgresDatabaseKey)
+	return &Config{
+		ConsoleCmdPrefix: strings.Split(viper.GetString(ConsoleCmdPrefixKey), " "),
+		ConsoleCmdDir:    viper.GetString(ConsoleCmdDirKey),
+		ConsoleCmd:       strings.Split(viper.GetString(ConsoleCmdKey), " "),
+		QueueNames:       viper.GetStringSlice(queueNamesKey),
+		SyncDataEntities: syncConfigEntities,
+		ResourceFilter:   viper.GetString(resourceKey),
+		RabbitMq: RabbitMQ{
+			ConnectionString: viper.GetString(rabbitmqConnectionStringKey),
+			Server:           viper.GetString(rabbitmqServerKey),
+			Port:             viper.GetInt(rabbitmqPortKey),
+			User:             viper.GetString(rabbitmqUserKey),
+			Password:         viper.GetString(rabbitmqPasswordKey),
+		},
+		Postgres: Postgres{
+			ConnectionString: viper.GetString(postgresConnectionStringKey),
+			Server:           viper.GetString(postgresServerKey),
+			Port:             viper.GetInt(postgresPortKey),
+			User:             viper.GetString(postgresUserKey),
+			Password:         viper.GetString(postgresPasswordKey),
+			Database:         viper.GetString(postgresDatabaseKey),
+		},
+	}
+}
 
-	return fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=disable", postgresUser, postgresPassword, postgresServer, postgresPort, postgresDatabase)
+func (r *RabbitMQ) GetConnectionString() string {
+	if r.ConnectionString != "" {
+		return r.ConnectionString
+	}
+
+	return fmt.Sprintf("amqp://%s:%s@%s:%d/", r.User, r.Password, r.Server, r.Port)
+}
+
+func (p *Postgres) GetConnectionString() string {
+	if p.ConnectionString != "" {
+		return p.ConnectionString
+	}
+
+	return fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=disable", p.User, p.Password, p.Server, p.Port, p.Database)
 }
 
 func countVerbosityLevel(args []string) int {

--- a/config/sync.go
+++ b/config/sync.go
@@ -9,6 +9,7 @@ type SyncEntity struct {
 	Locale       bool
 	QueueGroup   string `mapstructure:"queue_group"`
 	Mappings     []SyncEntityMapping
+	Params       map[string]string
 }
 
 type SyncEntityMapping struct {

--- a/container/container.go
+++ b/container/container.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Adaendra/uilive"
 	"github.com/Adaendra/uilive/pkg/writer"
 	"github.com/hgajjar/toolbox/config"
+	amqp "github.com/rabbitmq/amqp091-go"
 	"github.com/rs/zerolog"
 )
 
@@ -15,6 +16,7 @@ type Container struct {
 	writer *writer.Writer
 	logger *zerolog.Logger
 	db     *sql.DB
+	queue  *amqp.Connection
 }
 
 func New() *Container {
@@ -71,11 +73,29 @@ func (c *Container) DB() *sql.DB {
 	return c.db
 }
 
+func (c *Container) Queue() *amqp.Connection {
+	if c.queue == nil {
+		conn, err := amqp.Dial(config.GetRabbitMQConnectionString())
+		if err != nil {
+			c.Logger().Panic().Err(err).Msg("Failed to connect to RabbitMQ")
+		}
+		c.queue = conn
+	}
+
+	return c.queue
+}
+
 func (c *Container) Close() {
 	if c.db != nil {
 		err := c.db.Close()
 		if err != nil {
 			c.Logger().Error().Err(err).Msg("Failed to close Postgres connection")
+		}
+	}
+	if c.queue != nil {
+		err := c.queue.Close()
+		if err != nil {
+			c.Logger().Error().Err(err).Msg("Failed to close RabbitMQ connection")
 		}
 	}
 }

--- a/container/container.go
+++ b/container/container.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"database/sql"
 	"io"
 	"log"
 
@@ -13,6 +14,7 @@ import (
 type Container struct {
 	writer *writer.Writer
 	logger *zerolog.Logger
+	db     *sql.DB
 }
 
 func New() *Container {
@@ -55,4 +57,25 @@ func (c *Container) Logger() *zerolog.Logger {
 	}
 
 	return c.logger
+}
+
+func (c *Container) DB() *sql.DB {
+	if c.db == nil {
+		db, err := sql.Open("postgres", config.GetPostgresConnectionString())
+		if err != nil {
+			c.Logger().Panic().Err(err).Msg("Failed to connect to Postgres")
+		}
+		c.db = db
+	}
+
+	return c.db
+}
+
+func (c *Container) Close() {
+	if c.db != nil {
+		err := c.db.Close()
+		if err != nil {
+			c.Logger().Error().Err(err).Msg("Failed to close Postgres connection")
+		}
+	}
 }

--- a/container/container.go
+++ b/container/container.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"log"
 
+	_ "github.com/lib/pq"
+
 	"github.com/Adaendra/uilive"
 	"github.com/Adaendra/uilive/pkg/writer"
 	"github.com/hgajjar/toolbox/config"
@@ -23,13 +25,13 @@ func New() *Container {
 	return &Container{}
 }
 
-func (c *Container) Writer() (io.Writer, func()) {
+func (c *Container) Writer() io.Writer {
 	if c.writer == nil {
 		c.writer = uilive.New()
 		c.writer.Start()
 	}
 
-	return c.writer, func() { c.writer.Stop() }
+	return c.writer
 }
 
 func (c *Container) Logger() *zerolog.Logger {
@@ -61,9 +63,9 @@ func (c *Container) Logger() *zerolog.Logger {
 	return c.logger
 }
 
-func (c *Container) DB() *sql.DB {
+func (c *Container) DB(connStr string) *sql.DB {
 	if c.db == nil {
-		db, err := sql.Open("postgres", config.GetPostgresConnectionString())
+		db, err := sql.Open("postgres", connStr)
 		if err != nil {
 			c.Logger().Panic().Err(err).Msg("Failed to connect to Postgres")
 		}
@@ -73,9 +75,9 @@ func (c *Container) DB() *sql.DB {
 	return c.db
 }
 
-func (c *Container) Queue() *amqp.Connection {
+func (c *Container) Queue(connStr string) *amqp.Connection {
 	if c.queue == nil {
-		conn, err := amqp.Dial(config.GetRabbitMQConnectionString())
+		conn, err := amqp.Dial(connStr)
 		if err != nil {
 			c.Logger().Panic().Err(err).Msg("Failed to connect to RabbitMQ")
 		}
@@ -97,5 +99,8 @@ func (c *Container) Close() {
 		if err != nil {
 			c.Logger().Error().Err(err).Msg("Failed to close RabbitMQ connection")
 		}
+	}
+	if c.writer != nil {
+		c.writer.Stop()
 	}
 }

--- a/data/sync/models.go
+++ b/data/sync/models.go
@@ -9,6 +9,7 @@ type SyncEntity struct {
 	Data   string
 	Store  string
 	Locale string
+	Params map[string]string
 }
 
 func (p *SyncEntity) GetKey() string {
@@ -25,6 +26,10 @@ func (p *SyncEntity) GetStore() string {
 
 func (p *SyncEntity) GetLocale() string {
 	return p.Locale
+}
+
+func (p *SyncEntity) GetParams() map[string]string {
+	return p.Params
 }
 
 func (p *SyncEntity) IsNil() bool {

--- a/data/sync/repository.go
+++ b/data/sync/repository.go
@@ -64,7 +64,9 @@ func (r *Repository) GetData(ctx context.Context, filter data.Filter) (<-chan *S
 	dataCh := make(chan *SyncEntity)
 	go func() {
 		for rows.Next() {
-			entity := &SyncEntity{}
+			entity := &SyncEntity{
+				Params: r.config.Params,
+			}
 
 			if r.config.Store && r.config.Locale {
 				err = rows.Scan(&entity.Key, &entity.Data, &entity.Store, &entity.Locale)

--- a/integration/helper_test.go
+++ b/integration/helper_test.go
@@ -31,11 +31,14 @@ func setupRabbitMqService(ctx context.Context) (func(), string, error) {
 	})
 }
 
-func setupRabbitMqConnection(hostPort string) (*rabbitmq.Rabbitmq, error) {
+func setupRabbitMqConnection(ctx context.Context, hostPort string) (*rabbitmq.Rabbitmq, error) {
+	timeout := time.After(5 * time.Second)
 	for {
 		select {
-		case <-time.After(5 * time.Second):
+		case <-timeout:
 			return nil, errors.New("timed-out while waiting for rabbitmq service to start")
+		case <-ctx.Done():
+			return nil, ctx.Err()
 		default:
 			rmq, err := rabbitmq.New(rabbitmq.Config{
 				URL: fmt.Sprintf("amqp://guest:guest@127.0.0.1:%s/", hostPort),
@@ -81,7 +84,7 @@ func setupAndStartContainer(ctx context.Context, imageName string, ports []strin
 	portBindings := map[nat.Port][]nat.PortBinding{}
 
 	for _, port := range ports {
-		natPort := nat.Port(port)
+		natPort := nat.Port(port + "/tcp")
 		exposedPorts[natPort] = struct{}{}
 		portBindings[natPort] = []nat.PortBinding{{HostIP: "127.0.0.1", HostPort: "0"}}
 	}
@@ -133,10 +136,13 @@ func setupAndStartContainer(ctx context.Context, imageName string, ports []strin
 }
 
 func waitUntilContainerHealthy(ctx context.Context, dockerClient *client.Client, containerID string) error {
+	timeout := time.After(30 * time.Second)
 	for {
 		select {
-		case <-time.After(30 * time.Second):
+		case <-timeout:
 			return errors.New("timed-out while waiting for container to become healthy")
+		case <-ctx.Done():
+			return ctx.Err()
 		default:
 			info, err := dockerClient.ContainerInspect(ctx, containerID)
 			if err != nil {

--- a/integration/helper_test.go
+++ b/integration/helper_test.go
@@ -1,0 +1,161 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/client"
+	"github.com/docker/go-connections/nat"
+	"github.com/hgajjar/toolbox/integration/rabbitmq"
+	"github.com/pkg/errors"
+)
+
+const (
+	rmqDockerImage      = "docker.io/library/rabbitmq:3.9-management-alpine"
+	postgresDockerImage = "postgres:14.8"
+)
+
+func setupRabbitMqService(ctx context.Context) (func(), string, error) {
+	return setupAndStartContainer(ctx, rmqDockerImage, []string{"5672", "15672"}, nil, &container.HealthConfig{
+		Test:     []string{"CMD", "rabbitmq-diagnostics", "-q", "check_running"},
+		Interval: 5 * time.Second,
+		Timeout:  2 * time.Second,
+		Retries:  5,
+	})
+}
+
+func setupRabbitMqConnection(hostPort string) (*rabbitmq.Rabbitmq, error) {
+	for {
+		select {
+		case <-time.After(5 * time.Second):
+			return nil, errors.New("timed-out while waiting for rabbitmq service to start")
+		default:
+			rmq, err := rabbitmq.New(rabbitmq.Config{
+				URL: fmt.Sprintf("amqp://guest:guest@127.0.0.1:%s/", hostPort),
+			})
+			if err == nil {
+				return rmq, nil
+			}
+			time.Sleep(500 * time.Millisecond)
+		}
+	}
+}
+
+func setupPostgresService(ctx context.Context) (func(), string, error) {
+	return setupAndStartContainer(ctx, postgresDockerImage, []string{"5432"}, []string{"POSTGRES_PASSWORD=postgres"}, &container.HealthConfig{
+		Test:     []string{"CMD", "pg_isready", "-U", "postgres"},
+		Interval: 5 * time.Second,
+		Timeout:  2 * time.Second,
+		Retries:  5,
+	})
+}
+
+func buildPostgresConnStr(hostPort string) string {
+	return fmt.Sprintf("postgres://postgres:postgres@127.0.0.1:%s/postgres?sslmode=disable", hostPort)
+}
+
+func setupAndStartContainer(ctx context.Context, imageName string, ports []string, env []string, healthcheck *container.HealthConfig) (func(), string, error) {
+	dockerClient, err := client.NewClientWithOpts(client.FromEnv)
+	if err != nil {
+		panic(err)
+	}
+	deferFn := func() {
+		dockerClient.Close()
+	}
+
+	imagePullResp, err := dockerClient.ImagePull(ctx, imageName, image.PullOptions{})
+	if err != nil {
+		return deferFn, "", errors.Wrap(err, "failed to pull rabbitmq image")
+	}
+	defer imagePullResp.Close()
+	io.ReadAll(imagePullResp)
+
+	exposedPorts := nat.PortSet{}
+	portBindings := map[nat.Port][]nat.PortBinding{}
+
+	for _, port := range ports {
+		natPort := nat.Port(port)
+		exposedPorts[natPort] = struct{}{}
+		portBindings[natPort] = []nat.PortBinding{{HostIP: "127.0.0.1", HostPort: "0"}}
+	}
+
+	resp, err := dockerClient.ContainerCreate(ctx, &container.Config{
+		Image:        imageName,
+		ExposedPorts: exposedPorts,
+		Env:          env,
+		Healthcheck:  healthcheck,
+	}, &container.HostConfig{
+		PortBindings: portBindings,
+	}, nil, nil, "")
+
+	if err != nil {
+		return deferFn, "", errors.Wrap(err, "failed to create container")
+	}
+
+	deferFn = func() {
+		dockerClient.Close()
+		dockerClient.ContainerRemove(ctx, resp.ID, container.RemoveOptions{Force: true})
+	}
+
+	if err = dockerClient.ContainerStart(ctx, resp.ID, container.StartOptions{}); err != nil {
+		return deferFn, "", errors.Wrap(err, "failed to start container")
+	}
+
+	info, err := dockerClient.ContainerInspect(ctx, resp.ID)
+	if err != nil {
+		return deferFn, "", errors.Wrap(err, "failed to inspect container")
+	}
+	if info.State == nil || !info.State.Running {
+		logs, err := dockerClient.ContainerLogs(ctx, resp.ID, container.LogsOptions{ShowStdout: true, ShowStderr: true})
+		if err != nil {
+			return deferFn, "", errors.Wrap(err, "container is not running and failed to get logs")
+		}
+		defer logs.Close()
+		logData, _ := io.ReadAll(logs)
+		return deferFn, "", errors.Errorf("container is not running. Logs: %s", string(logData))
+	}
+
+	bindingPort := nat.Port(ports[0] + "/tcp")
+
+	err = waitUntilContainerHealthy(ctx, dockerClient, resp.ID)
+	if err != nil {
+		return deferFn, "", errors.Wrap(err, "container did not become healthy in time")
+	}
+
+	return deferFn, info.NetworkSettings.Ports[bindingPort][0].HostPort, nil
+}
+
+func waitUntilContainerHealthy(ctx context.Context, dockerClient *client.Client, containerID string) error {
+	for {
+		select {
+		case <-time.After(30 * time.Second):
+			return errors.New("timed-out while waiting for container to become healthy")
+		default:
+			info, err := dockerClient.ContainerInspect(ctx, containerID)
+			if err != nil {
+				return errors.Wrap(err, "failed to inspect container")
+			}
+			if info.State != nil && info.State.Health != nil && info.State.Health.Status == "healthy" {
+				return nil
+			}
+			time.Sleep(1 * time.Second)
+		}
+	}
+}
+
+func defineQueues(queueNames []string, rmq *rabbitmq.Rabbitmq) error {
+	for _, queue := range queueNames {
+		if err := rmq.Queue(queue); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/integration/queue_worker_test.go
+++ b/integration/queue_worker_test.go
@@ -29,7 +29,7 @@ func TestQueueWorker(t *testing.T) {
 
 	config.Verbose = 1
 
-	rmq, err := setupRabbitMqConnection(hostPort)
+	rmq, err := setupRabbitMqConnection(ctx, hostPort)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/integration/queue_worker_test.go
+++ b/integration/queue_worker_test.go
@@ -11,18 +11,10 @@ import (
 	"time"
 
 	"github.com/hgajjar/toolbox/config"
-	"github.com/hgajjar/toolbox/integration/rabbitmq"
 	"github.com/hgajjar/toolbox/queue"
-
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/image"
-	"github.com/docker/docker/client"
-	"github.com/docker/go-connections/nat"
-	"github.com/pkg/errors"
 )
 
 const (
-	rmqDockerImage = "docker.io/library/rabbitmq:3.9-management-alpine"
 	queueChunkSize = "100"
 )
 
@@ -44,10 +36,8 @@ func TestQueueWorker(t *testing.T) {
 	defer rmq.Close()
 
 	queues := []string{"test.product", "test.category", "test.user"}
-	for _, queue := range queues {
-		if err := rmq.Queue(queue); err != nil {
-			t.Fatal(err)
-		}
+	if err := defineQueues(queues, rmq); err != nil {
+		t.Fatal(err)
 	}
 
 	logger := io.Discard
@@ -150,68 +140,4 @@ func TestQueueWorker(t *testing.T) {
 			}
 		}
 	})
-}
-
-func setupRabbitMqService(ctx context.Context) (func(), string, error) {
-	dockerClient, err := client.NewClientWithOpts(client.FromEnv)
-	if err != nil {
-		panic(err)
-	}
-	deferFn := func() {
-		dockerClient.Close()
-	}
-
-	imagePullResp, err := dockerClient.ImagePull(ctx, rmqDockerImage, image.PullOptions{})
-	if err != nil {
-		return deferFn, "", errors.Wrap(err, "failed to pull rabbitmq image")
-	}
-	defer imagePullResp.Close()
-	io.ReadAll(imagePullResp)
-
-	resp, err := dockerClient.ContainerCreate(ctx, &container.Config{
-		Image:        rmqDockerImage,
-		ExposedPorts: nat.PortSet{"5672": struct{}{}, "15672": struct{}{}},
-	}, &container.HostConfig{
-		PortBindings: map[nat.Port][]nat.PortBinding{
-			nat.Port("5672"):  {{HostIP: "127.0.0.1", HostPort: "0"}},
-			nat.Port("15672"): {{HostIP: "127.0.0.1", HostPort: "0"}},
-		},
-	}, nil, nil, "")
-
-	if err != nil {
-		return deferFn, "", errors.Wrap(err, "failed to create rabbitmq container")
-	}
-
-	deferFn = func() {
-		dockerClient.Close()
-		dockerClient.ContainerRemove(ctx, resp.ID, container.RemoveOptions{Force: true})
-	}
-
-	if err = dockerClient.ContainerStart(ctx, resp.ID, container.StartOptions{}); err != nil {
-		return deferFn, "", errors.Wrap(err, "failed to start rabbitmq container")
-	}
-
-	info, err := dockerClient.ContainerInspect(ctx, resp.ID)
-	if err != nil {
-		return deferFn, "", errors.Wrap(err, "failed to inspect rabbitmq container")
-	}
-
-	return deferFn, info.NetworkSettings.Ports["5672/tcp"][0].HostPort, nil
-}
-
-func setupRabbitMqConnection(hostPort string) (*rabbitmq.Rabbitmq, error) {
-	for {
-		select {
-		case <-time.After(5 * time.Second):
-			return nil, errors.New("timed-out while waiting for rabbitmq service to start")
-		default:
-			rmq, err := rabbitmq.New(rabbitmq.Config{
-				URL: fmt.Sprintf("amqp://guest:guest@127.0.0.1:%s/", hostPort),
-			})
-			if err == nil {
-				return rmq, nil
-			}
-			time.Sleep(500 * time.Millisecond)
-		}
-	}
 }

--- a/integration/sync_data_test.go
+++ b/integration/sync_data_test.go
@@ -37,8 +37,15 @@ func TestSyncData(t *testing.T) {
 
 	db := dic.DB(buildPostgresConnStr(postgresHostPort))
 
-	rabbitmqPort, _ := strconv.Atoi(rabbitmqHostPort)
-	postgresPort, _ := strconv.Atoi(postgresHostPort)
+	rabbitmqPort, err := strconv.Atoi(rabbitmqHostPort)
+	if err != nil {
+		t.Fatalf("invalid RabbitMQ host port %q: %v", rabbitmqHostPort, err)
+	}
+	postgresPort, err := strconv.Atoi(postgresHostPort)
+	if err != nil {
+		t.Fatalf("invalid Postgres host port %q: %v", postgresHostPort, err)
+	}
+
 	cfg := &config.Config{
 		RabbitMq: config.RabbitMQ{
 			Server:   "127.0.0.1",
@@ -59,7 +66,7 @@ func TestSyncData(t *testing.T) {
 		URL: fmt.Sprintf("amqp://guest:guest@127.0.0.1:%s/", rabbitmqHostPort),
 	})
 	if err != nil {
-		log.Panic(err)
+		t.Fatalf("failed to create RabbitMQ client: %v", err)
 	}
 	defer rmq.Close()
 
@@ -175,14 +182,14 @@ func setupTestData(ctx context.Context, db *sql.DB) {
 	`)
 
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to set up test data: %v", err)
 	}
 }
 
 func consumeMessagesFromQueue(rmq *rabbitmq.Rabbitmq, queueName string) []string {
 	mCh, err := rmq.Consume(queueName, 100)
 	if err != nil {
-		log.Panic(err)
+		log.Fatalf("failed to consume messages from queue %q: %v", queueName, err)
 	}
 
 	var messages []string

--- a/integration/sync_data_test.go
+++ b/integration/sync_data_test.go
@@ -1,0 +1,194 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+	"strconv"
+	"testing"
+
+	"github.com/hgajjar/toolbox/config"
+	"github.com/hgajjar/toolbox/container"
+	"github.com/hgajjar/toolbox/integration/rabbitmq"
+	"github.com/hgajjar/toolbox/sync"
+)
+
+func TestSyncData(t *testing.T) {
+	ctx := context.Background()
+
+	closeFn, postgresHostPort, err := setupPostgresService(ctx)
+	defer closeFn()
+	if err != nil {
+		t.Fatalf("failed to setup postgres service: %v", err)
+	}
+
+	deferFn, rabbitmqHostPort, err := setupRabbitMqService(ctx)
+	defer deferFn()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dic := container.New()
+	defer dic.Close()
+
+	db := dic.DB(buildPostgresConnStr(postgresHostPort))
+
+	rabbitmqPort, _ := strconv.Atoi(rabbitmqHostPort)
+	postgresPort, _ := strconv.Atoi(postgresHostPort)
+	cfg := &config.Config{
+		RabbitMq: config.RabbitMQ{
+			Server:   "127.0.0.1",
+			Port:     rabbitmqPort,
+			User:     "guest",
+			Password: "guest",
+		},
+		Postgres: config.Postgres{
+			Server:   "127.0.0.1",
+			Port:     postgresPort,
+			User:     "postgres",
+			Password: "postgres",
+			Database: "postgres",
+		},
+	}
+
+	rmq, err := rabbitmq.New(rabbitmq.Config{
+		URL: fmt.Sprintf("amqp://guest:guest@127.0.0.1:%s/", rabbitmqHostPort),
+	})
+	if err != nil {
+		log.Panic(err)
+	}
+	defer rmq.Close()
+
+	if err := defineQueues([]string{"sync.search.cms", "sync.storage.cms"}, rmq); err != nil {
+		t.Fatal(err)
+	}
+
+	setupTestData(ctx, db)
+
+	t.Run("It publishes resource data with additional params", func(t *testing.T) {
+		cfg.SyncDataEntities = []config.SyncEntity{
+			{
+				Resource:     "cms_page_search",
+				Table:        "spy_cms_page_search",
+				IdColumn:     "id_cms_page_search",
+				FilterColumn: "fk_cms_page",
+				QueueGroup:   "sync.search.cms",
+				Store:        true,
+				Locale:       true,
+				Params: map[string]string{
+					"type": "page",
+				},
+			},
+		}
+
+		sync.RunSyncData(
+			ctx,
+			dic,
+			cfg,
+			sync.SyncDataArgs{},
+		)
+
+		messages := consumeMessagesFromQueue(rmq, "sync.search.cms")
+		if len(messages) != 3 {
+			t.Fatalf("expected 3 messages in the queue, got %d", len(messages))
+		}
+
+		expectedMessages := []string{
+			`{"write":{"key":"key1","value":{"test":"value1"},"resource":"cms_page_search","store":"US","params":{"type":"page"}}}`,
+			`{"write":{"key":"key2","value":{"test":"value2"},"resource":"cms_page_search","store":"US","params":{"type":"page"}}}`,
+			`{"write":{"key":"key3","value":{"test":"value3"},"resource":"cms_page_search","store":"US","params":{"type":"page"}}}`,
+		}
+
+		for i, msg := range messages {
+			if msg != expectedMessages[i] {
+				t.Errorf("expected message %d to be %s, got %s", i+1, expectedMessages[i], msg)
+			}
+		}
+	})
+
+	t.Run("It skips additional params when they are not configured", func(t *testing.T) {
+		cfg.SyncDataEntities = []config.SyncEntity{
+			{
+				Resource:     "cms_page",
+				Table:        "spy_cms_page_storage",
+				IdColumn:     "id_cms_page_storage",
+				FilterColumn: "fk_cms_page",
+				QueueGroup:   "sync.storage.cms",
+				Store:        true,
+				Locale:       true,
+			},
+		}
+
+		sync.RunSyncData(
+			ctx,
+			dic,
+			cfg,
+			sync.SyncDataArgs{},
+		)
+
+		messages := consumeMessagesFromQueue(rmq, "sync.storage.cms")
+		if len(messages) != 3 {
+			t.Fatalf("expected 3 messages in the queue, got %d", len(messages))
+		}
+
+		expectedMessages := []string{
+			`{"write":{"key":"key1","value":{"test":"value1"},"resource":"cms_page","store":"US"}}`,
+			`{"write":{"key":"key2","value":{"test":"value2"},"resource":"cms_page","store":"US"}}`,
+			`{"write":{"key":"key3","value":{"test":"value3"},"resource":"cms_page","store":"US"}}`,
+		}
+
+		for i, msg := range messages {
+			if msg != expectedMessages[i] {
+				t.Errorf("expected message %d to be %s, got %s", i+1, expectedMessages[i], msg)
+			}
+		}
+	})
+}
+
+func setupTestData(ctx context.Context, db *sql.DB) {
+	_, err := db.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS spy_cms_page_search (
+			id_cms_page_search SERIAL PRIMARY KEY,
+			fk_cms_page INTEGER,
+			key VARCHAR(255) NOT NULL,
+			data TEXT NOT NULL,
+			store VARCHAR(2),
+			locale VARCHAR(6)
+		);
+		INSERT INTO spy_cms_page_search (id_cms_page_search, fk_cms_page, key, data, store, locale) VALUES 
+		(1, 101, 'key1', '{"test": "value1"}', 'US', 'en_US'), (2, 102, 'key2', '{"test": "value2"}', 'US', 'en_US'), (3, 103, 'key3', '{"test": "value3"}', 'US', 'en_US');
+
+		CREATE TABLE IF NOT EXISTS spy_cms_page_storage (
+			id_cms_page_storage SERIAL PRIMARY KEY,
+			fk_cms_page INTEGER,
+			key VARCHAR(255) NOT NULL,
+			data TEXT NOT NULL,
+			store VARCHAR(2),
+			locale VARCHAR(6)
+		);
+		INSERT INTO spy_cms_page_storage (id_cms_page_storage, fk_cms_page, key, data, store, locale) VALUES 
+		(1, 101, 'key1', '{"test": "value1"}', 'US', 'en_US'), (2, 102, 'key2', '{"test": "value2"}', 'US', 'en_US'), (3, 103, 'key3', '{"test": "value3"}', 'US', 'en_US');
+	`)
+
+	if err != nil {
+		panic(err)
+	}
+}
+
+func consumeMessagesFromQueue(rmq *rabbitmq.Rabbitmq, queueName string) []string {
+	mCh, err := rmq.Consume(queueName, 100)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	var messages []string
+	for m := range mCh {
+		messages = append(messages, string(m))
+	}
+
+	return messages
+}

--- a/queue/connection.go
+++ b/queue/connection.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/hgajjar/toolbox/config"
 	amqp "github.com/rabbitmq/amqp091-go"
 	"github.com/rs/zerolog"
 )
@@ -17,9 +18,9 @@ func NewConnection(args WorkerArgs) *connection {
 	return &connection{args: args}
 }
 
-func (c *connection) Setup(ctx context.Context, args WorkerArgs) (*amqp.Connection, error) {
+func (c *connection) Setup(ctx context.Context, cfg *config.Config, args WorkerArgs) (*amqp.Connection, error) {
 	logger := zerolog.Ctx(ctx)
-	conn, err := amqp.Dial(args.RabbitmqConnString)
+	conn, err := amqp.Dial(cfg.RabbitMq.GetConnectionString())
 	if err != nil {
 		if !args.DaemonMode {
 			return nil, errors.New("failed to connect to RabbitMQ")
@@ -27,7 +28,7 @@ func (c *connection) Setup(ctx context.Context, args WorkerArgs) (*amqp.Connecti
 
 		// In daemon mode, we wait and retry connection with exponential backoff
 		logger.Error().Err(err).Msg("failed to connect to RabbitMQ, retrying...")
-		conn, err = c.waitAndRetry(ctx, args.RabbitmqConnString, logger)
+		conn, err = c.waitAndRetry(ctx, cfg.RabbitMq.GetConnectionString(), logger)
 		if err != nil {
 			return nil, err
 		}

--- a/queue/connection_test.go
+++ b/queue/connection_test.go
@@ -4,19 +4,15 @@ import (
 	"context"
 	"testing"
 	"time"
+
+	"github.com/hgajjar/toolbox/config"
 )
 
 func TestConnection_New(t *testing.T) {
-	args := WorkerArgs{
-		RabbitmqConnString: "amqp://guest:guest@localhost:5672/",
-	}
+	args := WorkerArgs{}
 	conn := NewConnection(args)
 	if conn == nil {
 		t.Fatal("Expected NewConnection to return a non-nil connection")
-	}
-
-	if conn.args.RabbitmqConnString != args.RabbitmqConnString {
-		t.Fatalf("Expected RabbitmqConnString to be %s, got %s", args.RabbitmqConnString, conn.args.RabbitmqConnString)
 	}
 }
 
@@ -25,13 +21,17 @@ func TestConnection_Setup(t *testing.T) {
 		t.Parallel()
 
 		args := WorkerArgs{
-			RabbitmqConnString: "amqp://guest:guest@invalid-host:5672/",
-			DaemonMode:         false,
+			DaemonMode: false,
+		}
+		cfg := &config.Config{
+			RabbitMq: config.RabbitMQ{
+				ConnectionString: "amqp://guest:guest@localhost:5672/",
+			},
 		}
 		conn := NewConnection(args)
 		ctx := context.Background()
 
-		_, err := conn.Setup(ctx, args)
+		_, err := conn.Setup(ctx, cfg, args)
 		if err == nil {
 			t.Fatal("Expected Setup to return an error when RabbitMQ is not running")
 		}
@@ -41,15 +41,19 @@ func TestConnection_Setup(t *testing.T) {
 		t.Parallel()
 
 		args := WorkerArgs{
-			RabbitmqConnString: "amqp://guest:guest@invalid-host:5672/",
-			DaemonMode:         true,
-			connectionTimeout:  time.Second * 3,
+			DaemonMode:        true,
+			connectionTimeout: time.Second * 3,
+		}
+		cfg := &config.Config{
+			RabbitMq: config.RabbitMQ{
+				ConnectionString: "amqp://guest:guest@invalid-host:5672/",
+			},
 		}
 		conn := NewConnection(args)
 		ctx := context.Background()
 		start := time.Now()
 
-		_, err := conn.Setup(ctx, args)
+		_, err := conn.Setup(ctx, cfg, args)
 		if err == nil {
 			t.Fatal("Expected Setup to return an error after retrying in DaemonMode when RabbitMQ is not running")
 		}

--- a/queue/connection_test.go
+++ b/queue/connection_test.go
@@ -25,7 +25,7 @@ func TestConnection_Setup(t *testing.T) {
 		}
 		cfg := &config.Config{
 			RabbitMq: config.RabbitMQ{
-				ConnectionString: "amqp://guest:guest@localhost:5672/",
+				ConnectionString: "amqp://guest:guest@invalid-host:5672/",
 			},
 		}
 		conn := NewConnection(args)

--- a/queue/service.go
+++ b/queue/service.go
@@ -9,31 +9,24 @@ import (
 )
 
 type WorkerArgs struct {
-	RabbitmqConnString string
-	Queues             []string
-	DaemonMode         bool
-	CmdPrefix          []string
-	CmdDir             string
-	Cmd                []string
-	connectionTimeout  time.Duration
+	DaemonMode        bool
+	connectionTimeout time.Duration
 }
 
-func StartWorker(ctx context.Context, dic *container.Container, args WorkerArgs) {
-	writer, stopFunc := dic.Writer()
-	defer stopFunc()
-
+func StartWorker(ctx context.Context, dic *container.Container, cfg *config.Config, args WorkerArgs) {
+	writer := dic.Writer()
 	logger := dic.Logger()
 
 	// Attach the Logger to the context.Context
 	ctx = logger.WithContext(ctx)
 
 	args.connectionTimeout = time.Hour
-	conn, err := NewConnection(args).Setup(ctx, args)
+	conn, err := NewConnection(args).Setup(ctx, cfg, args)
 	if err != nil {
 		logger.Panic().Err(err).Msg("failed to establish RabbitMQ connection")
 	}
 	defer conn.Close()
 
-	worker := NewWorker(conn, args.Queues, args.DaemonMode, args.CmdPrefix, args.CmdDir, args.Cmd, writer, config.QueueDeclareRetryWait)
+	worker := NewWorker(conn, cfg.QueueNames, args.DaemonMode, cfg.ConsoleCmdPrefix, cfg.ConsoleCmdDir, cfg.ConsoleCmd, writer, config.QueueDeclareRetryWait)
 	worker.Execute(ctx)
 }

--- a/sync/exporter.go
+++ b/sync/exporter.go
@@ -35,6 +35,7 @@ type EntityInterface interface {
 	GetKey() string
 	GetData() string
 	GetStore() string
+	GetParams() map[string]string
 	GenerateMappingKey(resourceName, source, sourceId string) string
 	IsNil() bool
 }
@@ -45,10 +46,11 @@ type MappingInterface interface {
 }
 
 type message struct {
-	Key      string `json:"key"`
-	Value    any    `json:"value"`
-	Resource string `json:"resource"`
-	Store    string `json:"store,omitempty"`
+	Key      string            `json:"key"`
+	Value    any               `json:"value"`
+	Resource string            `json:"resource"`
+	Store    string            `json:"store,omitempty"`
+	Params   map[string]string `json:"params,omitempty"`
 }
 
 type syncMessage struct {
@@ -148,6 +150,7 @@ func (e *Exporter) exportDataChunk(ctx context.Context, plugin SyncDataPluginInt
 				decodedVal,
 				plugin.GetResourceName(),
 				entity.GetStore(),
+				entity.GetParams(),
 			},
 		}
 		j, err := json.Marshal(m)

--- a/sync/service.go
+++ b/sync/service.go
@@ -17,16 +17,14 @@ import (
 )
 
 type SyncDataArgs struct {
-	RunQueueWorkerOpt  bool
-	Queues             []string
-	CmdPrefix          []string
-	CmdDir             string
-	Cmd                []string
-	SyncDataEntities   []config.SyncEntity
-	RabbitmqConnString string
-	PostgresConnString string
-	ResourceFilter     string
-	IDsOpt             string
+	RunQueueWorkerOpt bool
+	Queues            []string
+	CmdPrefix         []string
+	CmdDir            string
+	Cmd               []string
+	SyncDataEntities  []config.SyncEntity
+	ResourceFilter    string
+	IDsOpt            string
 }
 
 func RunSyncData(ctx context.Context, dic *container.Container, args SyncDataArgs) {

--- a/sync/service.go
+++ b/sync/service.go
@@ -44,19 +44,13 @@ func RunSyncData(ctx context.Context, dic *container.Container, args SyncDataArg
 	}
 	defer conn.Close()
 
-	dbconn, err := sql.Open("postgres", args.PostgresConnString)
-	if err != nil {
-		logger.Panic().Err(err).Msg("Failed to connect to Postgres")
-	}
-	defer dbconn.Close()
-
 	var workerDoneCh <-chan any
 	var queueWorker *queue.Worker
 	if args.RunQueueWorkerOpt {
 		workerDoneCh, queueWorker = startQueueWorker(ctx, args.Queues, conn, true, args.CmdPrefix, args.CmdDir, args.Cmd, writer)
 	}
 
-	exporter := NewExporter(conn, getSyncDataPlugins(dbconn, args.ResourceFilter, args.SyncDataEntities))
+	exporter := NewExporter(conn, getSyncDataPlugins(dic.DB(), args.ResourceFilter, args.SyncDataEntities))
 	err = exporter.Export(ctx, getIDs(ctx, args.IDsOpt))
 	if err != nil {
 		logger.Panic().Err(err).Msg("Failed to export data to rabbitmq")

--- a/sync/service.go
+++ b/sync/service.go
@@ -38,20 +38,14 @@ func RunSyncData(ctx context.Context, dic *container.Container, args SyncDataArg
 	// Attach the Logger to the context.Context
 	ctx = logger.WithContext(ctx)
 
-	conn, err := amqp.Dial(args.RabbitmqConnString)
-	if err != nil {
-		logger.Panic().Err(err).Msg("Failed to connect to RabbitMQ")
-	}
-	defer conn.Close()
-
 	var workerDoneCh <-chan any
 	var queueWorker *queue.Worker
 	if args.RunQueueWorkerOpt {
-		workerDoneCh, queueWorker = startQueueWorker(ctx, args.Queues, conn, true, args.CmdPrefix, args.CmdDir, args.Cmd, writer)
+		workerDoneCh, queueWorker = startQueueWorker(ctx, args.Queues, dic.Queue(), true, args.CmdPrefix, args.CmdDir, args.Cmd, writer)
 	}
 
-	exporter := NewExporter(conn, getSyncDataPlugins(dic.DB(), args.ResourceFilter, args.SyncDataEntities))
-	err = exporter.Export(ctx, getIDs(ctx, args.IDsOpt))
+	exporter := NewExporter(dic.Queue(), getSyncDataPlugins(dic.DB(), args.ResourceFilter, args.SyncDataEntities))
+	err := exporter.Export(ctx, getIDs(ctx, args.IDsOpt))
 	if err != nil {
 		logger.Panic().Err(err).Msg("Failed to export data to rabbitmq")
 	}

--- a/sync/service.go
+++ b/sync/service.go
@@ -18,31 +18,26 @@ import (
 
 type SyncDataArgs struct {
 	RunQueueWorkerOpt bool
-	Queues            []string
-	CmdPrefix         []string
-	CmdDir            string
-	Cmd               []string
-	SyncDataEntities  []config.SyncEntity
-	ResourceFilter    string
 	IDsOpt            string
 }
 
-func RunSyncData(ctx context.Context, dic *container.Container, args SyncDataArgs) {
-	writer, stopFunc := dic.Writer()
-	defer stopFunc()
-
+func RunSyncData(ctx context.Context, dic *container.Container, cfg *config.Config, args SyncDataArgs) {
+	writer := dic.Writer()
 	logger := dic.Logger()
 
 	// Attach the Logger to the context.Context
 	ctx = logger.WithContext(ctx)
 
+	queueConn := dic.Queue(cfg.RabbitMq.GetConnectionString())
+	dbConn := dic.DB(cfg.Postgres.GetConnectionString())
+
 	var workerDoneCh <-chan any
 	var queueWorker *queue.Worker
 	if args.RunQueueWorkerOpt {
-		workerDoneCh, queueWorker = startQueueWorker(ctx, args.Queues, dic.Queue(), true, args.CmdPrefix, args.CmdDir, args.Cmd, writer)
+		workerDoneCh, queueWorker = startQueueWorker(ctx, cfg.QueueNames, queueConn, true, cfg.ConsoleCmdPrefix, cfg.ConsoleCmdDir, cfg.ConsoleCmd, writer)
 	}
 
-	exporter := NewExporter(dic.Queue(), getSyncDataPlugins(dic.DB(), args.ResourceFilter, args.SyncDataEntities))
+	exporter := NewExporter(queueConn, getSyncDataPlugins(dbConn, cfg.ResourceFilter, cfg.SyncDataEntities))
 	err := exporter.Export(ctx, getIDs(ctx, args.IDsOpt))
 	if err != nil {
 		logger.Panic().Err(err).Msg("Failed to export data to rabbitmq")

--- a/toolbox.yml
+++ b/toolbox.yml
@@ -95,6 +95,8 @@ sync-data:
       store: true
       locale: true
       queue_group: sync.search.category
+      params:
+        type: page
     - resource: category_tree
       table: spy_category_tree_storage
       filter_column: id_category_tree_storage
@@ -139,6 +141,8 @@ sync-data:
       store: true
       locale: true
       queue_group: sync.search.cms
+      params:
+        type: page
     - resource: content
       table: spy_content_storage
       filter_column: fk_content
@@ -163,6 +167,8 @@ sync-data:
       store: false
       locale: true
       queue_group: sync.search.product #seems like a mistake on Spryker side
+      params:
+        type: page
     - resource: dynamic_config
       table: pyz_dynamic_config_storage
       filter_column: id_dynamic_config_storage
@@ -222,6 +228,8 @@ sync-data:
       store: true
       locale: true
       queue_group: sync.search.product
+      params:
+        type: page
     - resource: product_abstract_category
       table: spy_product_abstract_category_storage
       filter_column: fk_product_abstract
@@ -299,6 +307,8 @@ sync-data:
       store: true
       locale: true
       queue_group: sync.search.product
+      params:
+        type: page
     - resource: product_concrete
       table: spy_product_concrete_storage
       filter_column: fk_product


### PR DESCRIPTION
Spryker has added a new "params" section to the search resource sync payload. When this is missing, it fails to consume the messages.
I have allowed setting any additional "params" in the sync resource config itself, so it can be extended in future if required.

Changes:
- Allow passing "params" config in sync resource yaml
- Move creating rabbitmq and postgres clients in container
- Create new config object to hold values passed by viper, so it can be easily stubbed in test
- Add test suite for sync:data command